### PR TITLE
DbPDO::where change

### DIFF
--- a/system/classes/DbPDO.php
+++ b/system/classes/DbPDO.php
@@ -28,8 +28,8 @@ class DbPDO extends PDO {
 				$url = "{$config['driver']}:Server={$config['hostname']}{$port};Database={$config['database']}";
 				break;
 			//linux apache2 driver
-			case 'dblib':
-				$port = isset($config['port']) && !empty($config['port']) ? ",".$config['port'] : "";
+                            echo("Here in dblib ");
+				$port = isset($config['port']) && !empty($config['port']) ? ":".$config['port'] : "";
 				$url = "{$config['driver']}:host={$config['hostname']}{$port};dbname={$config['database']}";
 				break;			
 				//mysql
@@ -47,7 +47,7 @@ class DbPDO extends PDO {
         // heap for this var across all instances
         if (empty($this->table_names)){
 			$query = 'show tables';
-			if ($config['driver'] == 'sqlsrv') {
+			if ($config['driver'] == 'sqlsrv' || $config['driver'] == 'dblib')  {
 				$query = 'select TABLE_NAME from INFORMATION_SCHEMA.TABLES';
 			}
 			
@@ -140,7 +140,11 @@ class DbPDO extends PDO {
                 if (is_array($column)){
                     $this->query = $this->query->where($column);
                 } else {
+                if ($equals) {
                     $this->query = $this->query->where($column, $equals);
+                } else {
+                    $this->query = $this->query->where($column);
+                }
                 }
             }
         }

--- a/system/classes/DbPDO.php
+++ b/system/classes/DbPDO.php
@@ -28,7 +28,7 @@ class DbPDO extends PDO {
 				$url = "{$config['driver']}:Server={$config['hostname']}{$port};Database={$config['database']}";
 				break;
 			//linux apache2 driver
-                            echo("Here in dblib ");
+			case 'dblib':
 				$port = isset($config['port']) && !empty($config['port']) ? ":".$config['port'] : "";
 				$url = "{$config['driver']}:host={$config['hostname']}{$port};dbname={$config['database']}";
 				break;			

--- a/system/classes/DbPDO.php
+++ b/system/classes/DbPDO.php
@@ -131,7 +131,7 @@ class DbPDO extends PDO {
      * @param String $equals
      * @return \DbPDO|null
      */
-    public function where($column, $equals){
+    public function where($column, $equals = null){
         if ($this->query !== null){
             if (empty($column)){
                 // Resets the where part of the statement
@@ -140,11 +140,11 @@ class DbPDO extends PDO {
                 if (is_array($column)){
                     $this->query = $this->query->where($column);
                 } else {
-                if (count(func_get_args()) == 2) {
-                    $this->query = $this->query->where($column, $equals);
-                } else {
-                    $this->query = $this->query->where($column);
-                }
+                    if (count(func_get_args()) == 2) {
+                        $this->query = $this->query->where($column, $equals);
+                    } else {
+                        $this->query = $this->query->where($column);
+                    }
                 }
             }
         }

--- a/system/classes/DbPDO.php
+++ b/system/classes/DbPDO.php
@@ -131,7 +131,7 @@ class DbPDO extends PDO {
      * @param String $equals
      * @return \DbPDO|null
      */
-    public function where($column, $equals = null){
+    public function where($column, $equals){
         if ($this->query !== null){
             if (empty($column)){
                 // Resets the where part of the statement
@@ -140,7 +140,7 @@ class DbPDO extends PDO {
                 if (is_array($column)){
                     $this->query = $this->query->where($column);
                 } else {
-                if ($equals) {
+                if (count(func_get_args()) == 2) {
                     $this->query = $this->query->where($column, $equals);
                 } else {
                     $this->query = $this->query->where($column);


### PR DESCRIPTION
There are a couple of changes here:

**Linux Changes**
 A couple of tweaks to get the dblib driver working properly (accessing authority from linux)

**DbPDO::where Changes**
Change the where method to handle the $equals arg being null. This change fixed a problem I was having with a query in the BI Refactor with multiple where-> clauses. Deep down in the fluent pdo code I found that each clause was generating a parameter, even when there was not one. This was causing an exception due to a mismatch in the number of arguments to the query. 

Originally I simply checked for a null $equals, but null can actually be passed as a parameter. Instead, I removed the "= null" in the argument list and checked for 2 args. 

I am a little wary as I would have expected that this should have been encountered already, and wondered, as this is a very recent machine (latest s/w and all..), that maybe it could be related to my envinronment? I checked and it does not seem that fluentPdo has changed in a while. 

I was not able to extensively test, as I had difficulties logging on via Linux. However, I was able to test:
- bi refactor code via a test action - accessing both local mysql and authority
- attendance employee synchronise
- intelligence extract

The change to the DbPDO::where is required for the BI Refactor to work, as coded. The other changes were required to allow me to test against authority locally. More extensive regression testing is required, which I would like to do on attendance test.

Should this also be applied to 0-8-0-BRANCH?
