### PR TITLE
Add docker changes to config.ph via file

### DIFF
--- a/config.php.example
+++ b/config.php.example
@@ -82,6 +82,12 @@ Config::append('system.rest_allow',array(
     "Contact"
 ));
 
+// Allow for docker deployment changes to added via file
+if (file_exists("config.docker.php")) {
+    include ("config.docker.php");
+}
+
+// Allow individual deployments to add config changes via a file
 if (file_exists("config.override.php")) {
     include ("config.override.php");
 }


### PR DESCRIPTION
config.example.php was changed to allow for config changes directly relating to docker deployments to be included via a file, called config.docker.php